### PR TITLE
http to https

### DIFF
--- a/JQuery.html
+++ b/JQuery.html
@@ -4,9 +4,9 @@
 	<meta charset="UTF-8">
 		<title>JQuery</title>
     <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
-    <script src="http://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
+    <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
     <link rel="stylesheet"
-      href="http://code.jquery.com/ui/1.10.0/themes/base/jquery-ui.css">
+      href="https://code.jquery.com/ui/1.10.0/themes/base/jquery-ui.css">
 		<script>
       function load_value(value)
       {


### PR DESCRIPTION
In lab 6, some of the JQuery source links were using http to http in JQuery.html. This push changes all http links to https links. 